### PR TITLE
Fix deprecated actions/upload-artifact@v3 in workflows

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -67,7 +67,7 @@ jobs:
         outputs: type=docker,dest=/tmp/kasa-monitor-cached.tar
     
     - name: Upload build artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: kasa-monitor-cached
         path: /tmp/kasa-monitor-cached.tar
@@ -97,7 +97,7 @@ jobs:
         outputs: type=docker,dest=/tmp/kasa-monitor-no-cache.tar
     
     - name: Upload build artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: kasa-monitor-no-cache
         path: /tmp/kasa-monitor-no-cache.tar

--- a/.github/workflows/security-scanning.yml
+++ b/.github/workflows/security-scanning.yml
@@ -141,7 +141,7 @@ jobs:
         npm audit --json > npm-audit.json || true
 
     - name: Upload security reports
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: security-reports
@@ -227,7 +227,7 @@ jobs:
         npx license-checker --failOn "GPL-3.0;AGPL-3.0"
 
     - name: Upload license reports
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: license-reports


### PR DESCRIPTION
  ## 🔧 Fix: Deprecated GitHub Actions

  ### Problem
  - Dependency Vulnerability Scan was failing with deprecation error
  - `actions/upload-artifact@v3` is deprecated as of April 2024
  - Workflow failures preventing proper security scanning

  ### Solution
  - Updated all instances of `actions/upload-artifact@v3` to `@v4`
  - Fixed in `security-scanning.yml` and `docker-build-test.yml`
  - Maintains same functionality with updated API

  ### Files Changed
  - `.github/workflows/security-scanning.yml`
  - `.github/workflows/docker-build-test.yml`

  ### Testing
  - [ ] Security scanning workflow completes without deprecation warnings
  - [ ] Docker build test workflow continues to work properly
  - [ ] Artifact uploads function correctly with v4 API

  Fixes the workflow failures mentioned in the GitHub changelog:
  https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/