### PR TITLE
comprehensive update of GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -21,15 +21,15 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     
     - name: Cache pip packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -57,7 +57,7 @@ jobs:
         pylint backend/*.py --disable=C0111,R0903,R0913,W0613 || true
     
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
@@ -78,7 +78,7 @@ jobs:
       security-events: write
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Run Trivy security scan
       uses: aquasecurity/trivy-action@master
@@ -126,15 +126,15 @@ jobs:
           --health-retries 5
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     
     - name: Cache pip packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -162,7 +162,7 @@ jobs:
         python tests/test_framework.py
     
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         file: ./backend/coverage.xml
         flags: backend
@@ -174,10 +174,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
@@ -198,10 +198,10 @@ jobs:
     needs: [test-backend, test-frontend]
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
       with:
         driver-opts: |
           network=host
@@ -271,17 +271,17 @@ jobs:
       packages: write
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
       with:
         driver-opts: |
           network=host
           image=moby/buildkit:buildx-stable-1
     
     - name: Log in to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ${{ env.DOCKER_REGISTRY }}
         username: ${{ secrets.DOCKER_USERNAME }}
@@ -289,7 +289,7 @@ jobs:
     
     - name: Extract metadata
       id: meta
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v5
       with:
         images: ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
@@ -321,7 +321,7 @@ jobs:
           latest=false
     
     - name: Build and push Docker image
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: .
         platforms: linux/amd64,linux/arm64
@@ -354,7 +354,7 @@ jobs:
       deployments: write
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Deploy to staging
       run: |
@@ -376,10 +376,10 @@ jobs:
       deployments: write
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Create deployment
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       env:
         PRODUCTION_URL: ${{ secrets.PRODUCTION_URL || 'https://kasa-monitor.example.com' }}
       with:
@@ -423,7 +423,7 @@ jobs:
     
     - name: Update deployment status
       if: always()
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       env:
         PRODUCTION_URL: ${{ secrets.PRODUCTION_URL || 'https://kasa-monitor.example.com' }}
       with:
@@ -457,7 +457,7 @@ jobs:
       contents: write
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Create Release Notes
       id: release_notes
@@ -515,7 +515,7 @@ jobs:
         echo "\`\`\`" >> RELEASE_NOTES.md
     
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         body_path: RELEASE_NOTES.md
         draft: false

--- a/.github/workflows/cleanup-docker.yml
+++ b/.github/workflows/cleanup-docker.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - name: Find correct package name
       id: find_package
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           const packageNames = ['kasa-monitor', context.repo.repo, `${context.repo.owner}/${context.repo.repo}`];
@@ -52,7 +52,7 @@ jobs:
 
     - name: Delete old images
       if: steps.find_package.outputs.package_found == 'true'
-      uses: actions/delete-package-versions@v4
+      uses: actions/delete-package-versions@v5
       with:
         package-name: ${{ steps.find_package.outputs.package_name }}
         package-type: 'container'

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -31,10 +31,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
       with:
         driver-opts: |
           network=host
@@ -42,14 +42,14 @@ jobs:
     
     - name: Log in to Docker Hub (if secrets available)
       if: ${{ secrets.DOCKER_USERNAME && secrets.DOCKER_PASSWORD }}
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ${{ env.DOCKER_REGISTRY }}
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
     
     - name: Build with comprehensive caching
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: .
         platforms: linux/amd64
@@ -67,7 +67,7 @@ jobs:
         outputs: type=docker,dest=/tmp/kasa-monitor-cached.tar
     
     - name: Upload build artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: kasa-monitor-cached
         path: /tmp/kasa-monitor-cached.tar
@@ -81,13 +81,13 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
     
     - name: Build without cache
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: .
         platforms: linux/amd64
@@ -97,7 +97,7 @@ jobs:
         outputs: type=docker,dest=/tmp/kasa-monitor-no-cache.tar
     
     - name: Upload build artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: kasa-monitor-no-cache
         path: /tmp/kasa-monitor-no-cache.tar
@@ -112,13 +112,13 @@ jobs:
     
     steps:
     - name: Download cached build
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: kasa-monitor-cached
         path: /tmp/
     
     - name: Download no-cache build
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: kasa-monitor-no-cache
         path: /tmp/
@@ -154,10 +154,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
       with:
         driver-opts: |
           network=host
@@ -187,16 +187,16 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
       with:
         driver-opts: |
           network=host
     
     - name: First build (populate cache)
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: .
         platforms: linux/amd64
@@ -208,7 +208,7 @@ jobs:
           BUILDKIT_INLINE_CACHE=1
     
     - name: Second build (should use cache)
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: .
         platforms: linux/amd64

--- a/.github/workflows/manual-docker-cleanup.yml
+++ b/.github/workflows/manual-docker-cleanup.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
     - name: List packages (dry run)
       if: ${{ inputs.dry_run == 'true' }}
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           try {
@@ -94,7 +94,7 @@ jobs:
     - name: Find correct package name
       if: ${{ inputs.dry_run != 'true' }}
       id: find_package
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           const packageNames = ['kasa-monitor', context.repo.repo, `${context.repo.owner}/${context.repo.repo}`];
@@ -123,7 +123,7 @@ jobs:
 
     - name: Delete old package versions
       if: ${{ inputs.dry_run != 'true' && steps.find_package.outputs.package_found == 'true' }}
-      uses: actions/delete-package-versions@v4
+      uses: actions/delete-package-versions@v5
       with:
         package-name: ${{ steps.find_package.outputs.package_name }}
         package-type: 'container'

--- a/.github/workflows/pr-doc-checks.yml
+++ b/.github/workflows/pr-doc-checks.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0  # Need full history for comparison
       
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       

--- a/.github/workflows/security-scanning.yml
+++ b/.github/workflows/security-scanning.yml
@@ -105,7 +105,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
 
@@ -127,7 +127,7 @@ jobs:
         bandit -r . -ll
 
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '18'
         cache: 'npm'
@@ -141,7 +141,7 @@ jobs:
         npm audit --json > npm-audit.json || true
 
     - name: Upload security reports
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: security-reports
@@ -160,7 +160,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build Docker image for scanning
       run: |
@@ -197,7 +197,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
 
@@ -213,7 +213,7 @@ jobs:
         pip-licenses --fail-on="GPL v3;AGPL v3"
 
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '18'
         cache: 'npm'
@@ -227,7 +227,7 @@ jobs:
         npx license-checker --failOn "GPL-3.0;AGPL-3.0"
 
     - name: Upload license reports
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: license-reports


### PR DESCRIPTION
Updates all outdated GitHub Actions across workflows:

- actions/checkout@v3 → @v4 (multiple workflows)
- actions/setup-python@v4 → @v5 (security, CI/CD, PR docs)
- actions/setup-node@v3 → @v4 (security, CI/CD)
- actions/cache@v3 → @v4 (CI/CD)
- actions/upload-artifact@v3 → @v4 (security, docker-build)
- actions/download-artifact@v3 → @v4 (docker-build)
- actions/github-script@v6 → @v7 (CI/CD, cleanup workflows)
- actions/delete-package-versions@v4 → @v5 (cleanup workflows)
- codecov/codecov-action@v3 → @v4 (CI/CD)
- docker/setup-buildx-action@v2 → @v3 (security, CI/CD, docker-build)
- docker/login-action@v2 → @v3 (CI/CD, docker-build)
- docker/build-push-action@v4 → @v5 (CI/CD, docker-build)
- docker/metadata-action@v4 → @v5 (CI/CD)
- softprops/action-gh-release@v1 → @v2 (CI/CD)

This resolves deprecation warnings and ensures workflows use the latest stable versions with security improvements and performance enhancements.

🤖 Generated with [Claude Code](https://claude.ai/code)