### PR TITLE
Fix: Update JWT_SECRET_KEY in CI/CD to meet security requirements

### DIFF
--- a/.github/workflows/ci-cd-optimized.yml
+++ b/.github/workflows/ci-cd-optimized.yml
@@ -261,7 +261,7 @@ jobs:
     - name: Run backend tests
       env:
         SQLITE_PATH: test.db
-        JWT_SECRET_KEY: test_secret_key
+        JWT_SECRET_KEY: test-jwt-secret-key-for-ci-cd-pipeline-only-do-not-use-in-production
         REDIS_URL: redis://localhost:6379
       run: |
         cd backend


### PR DESCRIPTION
## Fix Backend Test Failures

The backend tests were failing in CI/CD with:
```
RuntimeError: JWT_SECRET_KEY environment variable is too short. Must be at least 32 characters for security.
```

## Root Cause
Our recent security enhancement requires JWT_SECRET_KEY to be at least 32 characters, but the CI/CD pipeline was using `test_secret_key` (only 15 characters).

## Solution
Updated the JWT_SECRET_KEY in the CI/CD workflow to a 68-character test key that meets security requirements.

### Changes
- **Old**: `JWT_SECRET_KEY=test_secret_key` (15 chars)
- **New**: `JWT_SECRET_KEY=test-jwt-secret-key-for-ci-cd-pipeline-only-do-not-use-in-production` (68 chars)

## Test Failures Fixed
- ✅ TestAuthentication::test_jwt_tokens
- ✅ TestIntegration::test_security_workflow

The key is clearly marked as test-only to prevent accidental production use.

🤖 Generated with Claude Code