### PR TITLE
Critical Fix: Add request parameter to rate-limited endpoints

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -1557,6 +1557,7 @@ class KasaMonitorApp:
         @self.app.post("/api/device/{device_ip}/control")
         @self.limiter.limit("60 per minute")
         async def control_device(
+            request: Request,
             device_ip: str,
             action: str = Query(...),
             current_user: User = Depends(
@@ -2233,7 +2234,7 @@ class KasaMonitorApp:
 
         @self.app.post("/api/auth/setup", response_model=User)
         @self.limiter.limit("3 per hour")
-        async def initial_setup(admin_data: UserCreate):
+        async def initial_setup(request: Request, admin_data: UserCreate):
             """Create initial admin user."""
             setup_required = await self.db_manager.is_setup_required()
             if not setup_required:
@@ -2454,7 +2455,9 @@ class KasaMonitorApp:
         @self.app.post("/api/auth/2fa/verify")
         @self.limiter.limit("10 per minute")
         async def verify_2fa(
-            verification_data: Dict[str, str], user: User = Depends(require_auth)
+            request: Request,
+            verification_data: Dict[str, str], 
+            user: User = Depends(require_auth)
         ):
             """Verify 2FA setup."""
             token = verification_data.get("token")
@@ -3578,6 +3581,7 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment"""
         @self.app.post("/api/export/devices")
         @self.limiter.limit("10 per hour")
         async def export_devices(
+            request: Request,
             format: str = "csv",
             include_energy: bool = True,
             user: User = Depends(require_permission(Permission.DATA_EXPORT)),
@@ -3669,6 +3673,7 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment"""
         @self.app.post("/api/export/energy")
         @self.limiter.limit("10 per hour")
         async def export_energy(
+            request: Request,
             device_ip: Optional[str] = None,
             start_date: Optional[datetime] = None,
             end_date: Optional[datetime] = None,


### PR DESCRIPTION
## Summary
- Fixed slowapi rate limiter error preventing Docker container startup
- Added required `request: Request` parameter to 5 endpoints

## Problem
The Docker container was failing with:
```
Exception: No "request" or "websocket" argument on function "<function KasaMonitorApp.setup_routes.<locals>.control_device at 0x7f87e58400>"
```

## Solution
Added `request: Request` parameter to all rate-limited endpoints that were missing it.

## Affected Endpoints
- `/api/device/{device_ip}/control`
- `/api/auth/setup`
- `/api/auth/2fa/verify`
- `/api/export/devices`
- `/api/export/energy`

## Test Plan
- [x] Added request parameter to all affected endpoints
- [ ] Docker container starts without exceptions
- [ ] Rate limiting functions correctly on all endpoints

🤖 Generated with [Claude Code](https://claude.ai/code)