### PR TITLE
Fix: Client-side filter error in device details view

### DIFF
--- a/src/components/chart-container.tsx
+++ b/src/components/chart-container.tsx
@@ -115,7 +115,9 @@ export function ChartContainer({
         throw new Error(`Failed to fetch chart data: ${response.statusText}`)
       }
       
-      return response.json()
+      const result = await response.json()
+      // Handle both array response and object with data property
+      return Array.isArray(result) ? result : (result.data || [])
     },
     // Use history-optimized configuration for better performance
     ...queryConfig.history,
@@ -125,7 +127,9 @@ export function ChartContainer({
   })
 
   // Filter data by time range (client-side backup if API doesn't support filtering)
-  const filteredData = rawData ? filterDataByTimeRange(rawData, timeRange) : []
+  // Ensure rawData is an array before passing to filterDataByTimeRange
+  const dataArray = Array.isArray(rawData) ? rawData : []
+  const filteredData = filterDataByTimeRange(dataArray, timeRange)
 
   const handleTimePeriodChange = useCallback((newPeriod: TimePeriodState) => {
     setTimePeriod(newPeriod)

--- a/src/lib/time-period-utils.ts
+++ b/src/lib/time-period-utils.ts
@@ -188,7 +188,8 @@ export function filterDataByTimeRange(
   data: ChartDataPoint[], 
   timeRange: ChartTimeRange
 ): ChartDataPoint[] {
-  if (!data || data.length === 0) {
+  // Ensure data is an array
+  if (!data || !Array.isArray(data) || data.length === 0) {
     return []
   }
 


### PR DESCRIPTION
## Summary
- Fixed "y.filter is not a function" error when viewing device details
- Properly handles API response format with nested data structure

## Problem
The device history API endpoint returns:
```json
{
  "data": [...],
  "metadata": {...}
}
```
But the frontend expected a plain array, causing a TypeError when trying to filter the data.

## Solution
1. Updated `ChartContainer` to extract the data array from the API response
2. Added defensive checks in `filterDataByTimeRange` to ensure data is an array
3. Handle both legacy array format and new object format for compatibility

## Test Plan
- [x] Fixed filter function to handle non-array inputs
- [x] Updated API response parsing to extract data array
- [ ] Device details view loads without errors
- [ ] Charts display historical data correctly

🤖 Generated with [Claude Code](https://claude.ai/code)