### PR TITLE
Fix: Add authentication headers to API calls

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -5,7 +5,7 @@ import { AppLayout } from '@/components/app-layout'
 import { useAuth } from '@/contexts/auth-context'
 import { User, Mail, Shield, Trash2, Save, AlertTriangle, CheckCircle, X } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import axios from 'axios'
+import axios from '@/lib/axios-config'
 import { safeConsoleError, safeStorage } from '@/lib/security-utils'
 
 export default function ProfilePage() {

--- a/src/components/chart-container.tsx
+++ b/src/components/chart-container.tsx
@@ -110,7 +110,10 @@ export function ChartContainer({
         url.searchParams.set('time_period', apiParams.time_period)
       }
 
-      const response = await fetch(url.toString())
+      const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null
+      const response = await fetch(url.toString(), {
+        headers: token ? { 'Authorization': `Bearer ${token}` } : {}
+      })
       if (!response.ok) {
         throw new Error(`Failed to fetch chart data: ${response.statusText}`)
       }

--- a/src/components/cost-summary.tsx
+++ b/src/components/cost-summary.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
-import axios from 'axios'
+import axios from '@/lib/axios-config'
 import { DollarSign, TrendingUp, Calendar, Zap } from 'lucide-react'
 import { useState } from 'react'
 

--- a/src/components/device-card.tsx
+++ b/src/components/device-card.tsx
@@ -3,7 +3,7 @@
 import { Power, Zap, Activity } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import axios from 'axios'
+import axios from '@/lib/axios-config'
 import { io, Socket } from 'socket.io-client'
 import { CompactExportButton } from './export-button'
 import { DataExportModal } from './data-export-modal'

--- a/src/components/device-controls.tsx
+++ b/src/components/device-controls.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { Power } from 'lucide-react'
-import axios from 'axios'
+import axios from '@/lib/axios-config'
 import { safeConsoleError, safeStorage, createSafeApiUrl } from '@/lib/security-utils'
 
 interface DeviceControlsProps {

--- a/src/components/device-detail.tsx
+++ b/src/components/device-detail.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
-import axios from 'axios'
+import axios from '@/lib/axios-config'
 import { ArrowLeft, Power, Zap, Activity, TrendingUp } from 'lucide-react'
 import { PowerChart } from './charts/power-chart'
 import { VoltageChart } from './charts/voltage-chart'

--- a/src/components/device-grid.tsx
+++ b/src/components/device-grid.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
-import axios from 'axios'
+import axios from '@/lib/axios-config'
 import { Power, Wifi, Zap } from 'lucide-react'
 import { DeviceCard } from './device-card'
 

--- a/src/components/discovery-modal.tsx
+++ b/src/components/discovery-modal.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { X, Search, User, Lock } from 'lucide-react'
-import axios from 'axios'
+import axios from '@/lib/axios-config'
 import { useQueryClient } from '@tanstack/react-query'
 
 interface DiscoveryModalProps {

--- a/src/components/electricity-rates-modal.tsx
+++ b/src/components/electricity-rates-modal.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { X, DollarSign, Clock, Save, Plus, Trash2, Info } from 'lucide-react'
-import axios from 'axios'
+import axios from '@/lib/axios-config'
 import { safeConsoleError } from '@/lib/security-utils'
 
 interface ElectricityRatesModalProps {

--- a/src/lib/axios-config.ts
+++ b/src/lib/axios-config.ts
@@ -1,0 +1,51 @@
+import axios from 'axios'
+
+// Create axios instance with default config
+const axiosInstance = axios.create({
+  baseURL: typeof window !== 'undefined' ? window.location.origin : '',
+  timeout: 30000,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+})
+
+// Add request interceptor to include auth token
+axiosInstance.interceptors.request.use(
+  (config) => {
+    // Get token from localStorage
+    const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null
+    
+    // Add token to headers if it exists
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`
+    }
+    
+    return config
+  },
+  (error) => {
+    return Promise.reject(error)
+  }
+)
+
+// Add response interceptor to handle auth errors
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    // If we get a 401, redirect to login
+    if (error.response?.status === 401) {
+      // Only redirect if we're not already on the login page
+      if (typeof window !== 'undefined' && !window.location.pathname.includes('/login')) {
+        // Clear invalid token
+        localStorage.removeItem('token')
+        localStorage.removeItem('user')
+        
+        // Redirect to login
+        window.location.href = '/login'
+      }
+    }
+    
+    return Promise.reject(error)
+  }
+)
+
+export default axiosInstance


### PR DESCRIPTION
## Summary
- Fixed authentication errors when viewing devices and exporting data
- All API calls now include Bearer token authentication

## Problem
Users were getting authentication errors (appearing as poetic messages about "rebels" and "troublemakers") when:
- Viewing device details
- Exporting data
- Accessing device information

The issue was that axios and fetch calls weren't including authentication headers.

## Solution
1. Created centralized axios configuration with auth interceptor
2. Updated all components to use the configured axios instance
3. Added authentication headers to fetch calls in ChartContainer
4. Added automatic redirect to login on 401 responses

## Components Updated
- device-grid.tsx
- device-detail.tsx
- device-card.tsx
- device-controls.tsx
- cost-summary.tsx
- electricity-rates-modal.tsx
- discovery-modal.tsx
- chart-container.tsx
- profile/page.tsx

## Test Plan
- [x] Created axios interceptor for auth headers
- [x] Updated all axios imports
- [x] Added auth to fetch calls
- [ ] Device view loads with authentication
- [ ] Export functionality works with auth
- [ ] 401 errors redirect to login

🤖 Generated with [Claude Code](https://claude.ai/code)